### PR TITLE
Bring back pdf link and tracking number

### DIFF
--- a/regulations/static/regulations/js/source/views/comment/comment-confirm-view.js
+++ b/regulations/static/regulations/js/source/views/comment/comment-confirm-view.js
@@ -14,8 +14,6 @@ var CommentConfirmView = Backbone.View.extend({
   initialize: function(options) {
     Backbone.View.prototype.setElement.call(this, '#' + options.id);
 
-    this.findElms();
-
     this.docId = this.$el.data('doc-id');
     this.metadataUrl = this.$el.data('metadata-url');
 
@@ -25,11 +23,6 @@ var CommentConfirmView = Backbone.View.extend({
         comment.destroy();
       });
     }
-  },
-
-  findElms: function() {
-    this.$pdf = this.$el.find('.pdf');
-    this.$status = this.$el.find('.status');
   },
 
   poll: function(url) {
@@ -47,12 +40,27 @@ var CommentConfirmView = Backbone.View.extend({
     );
   },
 
+  /**
+   * Fill in an element's (indicated by the selector) template with the ctx
+   * provided
+   **/
+  replaceTemplate: function(selector, ctx) {
+    this.$el.find(selector).each(function(idx, elt) {
+      var $elt = $(elt);
+      var $tplElt = $elt.find('.js-template');
+      var result = _.template($tplElt.prop('innerHTML'))(ctx);
+      $elt.empty();
+      $elt.append($tplElt);
+      $elt.append(result);
+    });
+  },
+
   setPdfUrl: function(url) {
-    this.$pdf.html('<a href="' + url + '">Download PDF</a>');
+    this.replaceTemplate('.save-pdf', {url: url});
   },
 
   setTrackingNumber: function(number) {
-    this.$status.html('<div>Comment tracking number: ' + number + '</div>');
+    this.replaceTemplate('.tracking-number .status', {number: number});
   }
 });
 

--- a/regulations/templates/regulations/comment-confirm-success.html
+++ b/regulations/templates/regulations/comment-confirm-success.html
@@ -8,26 +8,32 @@
       <p>Thank you for submitting your comment to EPA. You're done!</p>
     </div>
   </div>
-<!--
   <div class="save-pdf">
-    <div class="fa fa-file-pdf-o"></div>
-    <div class="save-pdf-text">
-      <h3>Want to save a copy for yourself?</h3>
-      <a href="">Download your submitted comment (PDF)</a>
-    </div>
+    <script class="js-template" type="text/template">
+      <div class="fa fa-file-pdf-o"></div>
+      <div class="save-pdf-text">
+        <h3>Want to save a copy for yourself?</h3>
+        <a href="<%= url %>">Download your submitted comment (PDF)</a>
+      </div>
+    </script>
   </div>
-
   <section class="tracking-number">
     <h3>Your comment tracking number</h3>
     <p>
       The first step EPA takes is to assign your comment a tracking number.
       This page automatically displays that number when received:
     </p>
+    <p class="status">
+      Waiting to receive comment tracking number. This may take a few seconds
+      or minutes.
+      <script class="js-template" type="text/template">
+        <div>Comment tracking number: <%= number %></div>
+      </script>
+    </p>
     <p>
       Your comment tracking number can help you find and view your public comment later if you want to.
     </p>
   </section>
--->
   <section class="what-will-happen">
 
     <h3>What will happen to your comment</h3>


### PR DESCRIPTION
This uses underscore templates so that the templates associated with the PDF
download and tracking number are part of the markup (rather than only being
present in the JS)

<img width="702" alt="screen shot 2016-05-27 at 7 02 11 pm" src="https://cloud.githubusercontent.com/assets/326918/15623096/1e172664-243e-11e6-91f3-b652b4b590ef.png">
